### PR TITLE
Olympic Stadium Baku (Azerbaijan) Longitude

### DIFF
--- a/data.json
+++ b/data.json
@@ -40,7 +40,7 @@
       "country": "Azerbaijan",
       "coords": {
         "latitude": 40.4299621,
-        "longitude": -49.9174133
+        "longitude": 49.9174133
       },
       "image": "https://upload.wikimedia.org/wikipedia/commons/b/bb/Baku_Olympic_Stadium_panorama_1.JPG"
     },


### PR DESCRIPTION
The Longitude in the Olympic Stadium coords was pointing to somewhere in the ocean. 
Removed the incorrect '-' character.